### PR TITLE
Fixes #12 - incorrect sort order during a build.

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -131,11 +131,15 @@
   getJobs = function(filter, next) {
     return db.collection('jobs', function(error, collection) {
       if (filter != null) {
-        return collection.find(filter).toArray(function(error, results) {
+        return collection.find(filter).sort({
+          addedTime: 1
+        }).toArray(function(error, results) {
           return next(results);
         });
       } else {
-        return collection.find().toArray(function(error, results) {
+        return collection.find().sort({
+          addedTime: 1
+        }).toArray(function(error, results) {
           return next(results);
         });
       }

--- a/src/jobs.coffee
+++ b/src/jobs.coffee
@@ -91,8 +91,8 @@ jobs = module.exports =
 getJobs = (filter, next)->
     db.collection 'jobs', (error, collection) ->
         if filter?
-            collection.find(filter).toArray (error, results) ->
+            collection.find(filter).sort({addedTime: 1}).toArray (error, results) ->
                 next results
         else
-            collection.find().toArray (error, results) ->
+            collection.find().sort({addedTime: 1}).toArray (error, results) ->
                 next results


### PR DESCRIPTION
- Spotting that MongoHub was also listing the 
  current build in a random order, I fixed this 
  issue by just forcing a sort order. Performance
  doesn't seem like it's the most important thing
  for an app like this.
- I wonder if the issue is related to natural vs
  insertion sort order, see:
  http://www.mongodb.org/display/DOCS/Sorting+and+Natural+Order
