### PR TITLE
Changed to use the stdout instead of error.  Error only has the status c...

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -92,7 +92,7 @@
     }, __bind(function(error, stdout, stderr) {
       var err, out;
       if (error != null) {
-        err = html(tokenize(error.toString()));
+        err = html(tokenize(stdout.toString()));
         return jobs.updateLog(jobs.current, "<span class='output error'>" + err + "</span>", function() {
           console.log(("" + err).red);
           return runFile(git.failure, next, false);
@@ -115,7 +115,7 @@
       return exec(file, __bind(function(error, stdout, stderr) {
         var err, out;
         if (error != null) {
-          err = html(tokenize(error.toString()));
+          err = html(tokenize(stdout.toString()));
           return jobs.updateLog(jobs.current, "<span class='output error'>" + err + "</span>", function() {
             next(args);
             return console.log(("" + err).red);


### PR DESCRIPTION
...ode and the signal.  Testing framework will output to stdout and that is what you want anyways.
