### PR TITLE
Fetch/reset instead of git pull

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -36,8 +36,9 @@
       jobs = require('./jobs');
       out = "Pulling '" + git.branch + "' branch";
       return jobs.updateLog(jobs.current, out, function() {
+        var _this = this;
         console.log(out.grey);
-        return exec('git pull origin ' + git.branch, __bind(function(error, stdout, stderr) {
+        return exec('git fetch && git reset --hard origin/' + git.branch, function(error, stdout, stderr) {
           if (error != null) {
             out = "" + error;
             jobs.updateLog(jobs.current, out);

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -53,7 +53,7 @@ git = module.exports =
         out = "Pulling '#{git.branch}' branch"
         jobs.updateLog jobs.current, out, ->
             console.log out.grey
-            exec 'git pull origin ' + git.branch, (error, stdout, stderr)=>
+            exec 'git fetch && git reset --hard origin/' + git.branch, (error, stdout, stderr)=>
                 if error?
                     out = "#{error}"
                     jobs.updateLog jobs.current, out


### PR DESCRIPTION
git pull has potential for merge conflicts and other problems in the
background. Since we're never pushing from concrete's repo, we're safe
to do a fetch/reset --hard. This will ensure we're always getting
updated to the correct point with no issues.
