### PR TITLE
add require for fs usage

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,5 @@
 (function() {
+  var fs = require('fs');
   var colors, exec, getBranch, getRunner, git, gitContinue, readyCallback;
   var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   exec = require('child_process').exec;


### PR DESCRIPTION
Commit https://github.com/ryankee/concrete/commit/301a83b324f85396c225cc426f92e0008f9e20b4 introduced `fs` instead of `path` since node API changed. However, `fs` needs to be required to be used
